### PR TITLE
MVP version with software and bridged networking

### DIFF
--- a/internal/afpacket/afpacket.go
+++ b/internal/afpacket/afpacket.go
@@ -38,6 +38,7 @@ func RawSocket(ifIndex int) (*os.File, error) {
 	return os.NewFile(uintptr(rawSocketFD), "raw socket"), nil
 }
 
+// htons converts a value from host to network byte order.
 func htons(hostshort uint16) uint16 {
 	repr := make([]byte, 2)
 


### PR DESCRIPTION
Unfortunately, the stock version of [`passt`](https://passt.top/passt/about/) is unable to operate correctly with the TAP devices or [`packet(7)`](https://man7.org/linux/man-pages/man7/packet.7.html) sockets we pass to it, so a [patched version of passt is required](https://github.com/edigaryev/passt/tree/tap-fd). The patch [is sent upstream](https://archives.passt.top/passt-dev/20230915142152.73499-1-edigaryev@gmail.com/) and hopefully it will be merged soon.

To try `vetu`, spawn a new codespace from the `<> Code` menu on the upper-left part of the screen:

<img width="414" alt="Screenshot 2023-09-18 at 21 51 34" src="https://github.com/cirruslabs/vetu/assets/85709/d144b36c-8156-4dd8-9e7b-faee9312a285">

Then, download a generic bootloader, Ubuntu cloud disk image and build a cloud-init image (so that we'd be able to use `vetu:vetu` credentials after the VM boots):

```sh
wget -O hypervisor-fw https://github.com/cloud-hypervisor/rust-hypervisor-firmware/releases/download/0.4.2/hypervisor-fw
wget -O ubuntu.img https://cloud-images.ubuntu.com/focal/current/focal-server-cloudimg-amd64.img && qemu-img convert -p -f qcow2 -O raw ubuntu.img ubuntu.raw
make -C tools/cloud-init
```

Build `vetu` binary and give it the `CAP_NET_ADMIN` and `CAP_NET_RAW` capabilities:

```sh
go build -o vetu cmd/vetu/main.go
sudo setcap cap_net_raw,cap_net_admin+eip ./vetu
```

Now, you're ready to create a Linux VM:

```sh
./vetu create linux --kernel hypervisor-fw --disk ubuntu.raw --disk tools/cloud-init/cloud-init.iso
```

Run the VM:

```
./vetu run linux
```

Once it boots and displays a `linux login:` line, you can either log-in via the console using `vetu:vetu` credentials, or connect to the VM via SSH, similarly to Tart:

```sh
ssh vetu@$(./vetu ip linux)
```