### PR TITLE
vetu list: support --source and -q/--quiet

### DIFF
--- a/internal/command/list/list.go
+++ b/internal/command/list/list.go
@@ -13,6 +13,9 @@ import (
 
 type listFunc func() ([]lo.Tuple2[string, *vmdirectory.VMDirectory], error)
 
+var source string
+var quiet bool
+
 func NewCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
@@ -21,20 +24,55 @@ func NewCommand() *cobra.Command {
 		Args:  cobra.ExactArgs(0),
 	}
 
+	cmd.Flags().StringVar(&source, "source", "",
+		"only display VMs from the specified source (e.g. --source local or --source oci)")
+	cmd.Flags().BoolVarP(&quiet, "quiet", "q", false, "only display VM names")
+
 	return cmd
 }
 
 func runList(cmd *cobra.Command, args []string) error {
+	desiredSources := map[string]listFunc{}
+
+	// Support --source
+	switch source {
+	case "local":
+		desiredSources["local"] = local.List
+	case "oci":
+		desiredSources["oci"] = remote.List
+	case "":
+		desiredSources["local"] = local.List
+		desiredSources["oci"] = remote.List
+	default:
+		return fmt.Errorf("cannot display VMs from an unsupported source %q", source)
+	}
+
+	// Support -q/--quiet
+	if quiet {
+		for _, list := range desiredSources {
+			vms, err := list()
+			if err != nil {
+				return err
+			}
+
+			for _, vm := range vms {
+				name, _ := lo.Unpack2(vm)
+
+				fmt.Println(name)
+			}
+		}
+
+		return nil
+	}
+
 	table := uitable.New()
 
 	table.AddRow("Source", "Name", "Size")
 
-	if err := addVMs(local.List, "local", table); err != nil {
-		return err
-	}
-
-	if err := addVMs(remote.List, "oci", table); err != nil {
-		return err
+	for source, vmListFunc := range desiredSources {
+		if err := addVMsToTable(table, source, vmListFunc); err != nil {
+			return err
+		}
 	}
 
 	fmt.Println(table.String())
@@ -42,7 +80,7 @@ func runList(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func addVMs(list listFunc, source string, table *uitable.Table) error {
+func addVMsToTable(table *uitable.Table, source string, list listFunc) error {
 	vms, err := list()
 	if err != nil {
 		return err


### PR DESCRIPTION
`--quiet` is needed for Tart CLI integration and `--source` was just added to provide the feature parity with Tart.