### PR TITLE
gVisor networking: fix communication in the Vetu network

### DIFF
--- a/internal/network/software/software.go
+++ b/internal/network/software/software.go
@@ -71,7 +71,7 @@ func New(vmHardwareAddr net.HardwareAddr) (*Network, error) {
 	if err := netlink.AddrAdd(vmLink, &netlink.Addr{
 		IPNet: &net.IPNet{
 			IP:   hostIP,
-			Mask: network.GetNetworkMask().Bytes(),
+			Mask: network.Mask,
 		},
 	}); err != nil {
 		return nil, fmt.Errorf("%w: failed to assign address %s to an interface %q: %v",
@@ -84,7 +84,7 @@ func New(vmHardwareAddr net.HardwareAddr) (*Network, error) {
 			ErrInitFailed, vmLink.Attrs().Name, err)
 	}
 
-	gvisor, err := gvisor.New(rawSocketFD, gatewayIP)
+	gvisor, err := gvisor.New(rawSocketFD, gatewayIP, network)
 	if err != nil {
 		return nil, fmt.Errorf("%w: %v", ErrInitFailed, err)
 	}


### PR DESCRIPTION
Before this PR, it was not possible to reach the VM from the host, because the forwarding was attempted instead of letting the packets go to their endpoint freely.

Now both internet access in the VM and SSH to the VM works just fine.