### PR TITLE
Bridged networking: bring up the TAP interface

### DIFF
--- a/internal/network/bridged/bridged.go
+++ b/internal/network/bridged/bridged.go
@@ -30,12 +30,18 @@ func New(bridgeName string) (*Network, error) {
 	// Locate the TAP interface
 	tapLink, err := netlink.LinkByName(tapName)
 	if err != nil {
-		return nil, fmt.Errorf("bridge %q not found: %v", bridgeName, err)
+		return nil, fmt.Errorf("failed to find the TAP interface %q that we've just created: %v",
+			tapName, err)
+	}
+
+	// Bring the TAP interface up
+	if err := netlink.LinkSetUp(tapLink); err != nil {
+		return nil, fmt.Errorf("failed to bring the TAP interface %q up: %v", tapName, err)
 	}
 
 	// Attach the TAP interface to the bridge
 	if err := netlink.LinkSetMaster(tapLink, bridgeLink); err != nil {
-		return nil, fmt.Errorf("failed to attach TAP interface %q to the bridge interface %q: %v",
+		return nil, fmt.Errorf("failed to attach the TAP interface %q to the bridge %q: %v",
 			tapName, bridgeName, err)
 	}
 


### PR DESCRIPTION
Otherwise we'll get an I/O error when attempting to read or write from that TAP interface from Cloud Hypervisor.