### PR TITLE
vetu run: introduce host networking (--net-host)

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -62,7 +62,7 @@ Check the [releases page](https://github.com/cirruslabs/vetu/releases) for a pre
 Here's a one-liner for Linux to download the latest release:
 
 ```bash
-curl -L -o vetu https://github.com/cirruslabs/vetu/releases/latest/download/vetu-linux-$(uname -m) && sudo mv vetu /usr/bin/vetu && sudo chmod +x /usr/bin/vetu && sudo setcap cap_net_raw,cap_net_admin+eip /usr/bin/vetu
+curl -L -o vetu https://github.com/cirruslabs/vetu/releases/latest/download/vetu-linux-$(uname -m) && sudo mv vetu /usr/bin/vetu && sudo chmod +x /usr/bin/vetu && sudo setcap cap_net_raw,cap_net_admin,cap_net_bind_service+eip /usr/bin/vetu
 ```
 
 ## From Source
@@ -78,7 +78,7 @@ This will build and place the `vetu` binary in `$GOPATH/bin`.
 Vetu binary also needs some capabilities assigned to it:
 
 ```shell
-sudo setcap cap_net_raw,cap_net_admin+eip $GOPATH/bin/vetu
+sudo setcap cap_net_raw,cap_net_admin,cap_net_bind_service+eip $GOPATH/bin/vetu
 ```
 
 To be able to run `vetu` command from anywhere, make sure the `$GOPATH/bin` directory is added to your `PATH`

--- a/README.md
+++ b/README.md
@@ -48,7 +48,16 @@ However, this choice is still fast enough to run most of the tasks, for example,
 
 Bridged networking can be enabling by specifying `--net-bridged=BRIDGE_INTERFACE_NAME` argument to `vetu run` and has an advantage of being fast, because all the processing and routing is done in the kernel.
 
-The main disadvantage is that this choice requires the system administrator to properly configure the bridge interface, IP forwarding, DHCP server (if required by the VM) and the packet filter to provide adequate network isolation.
+The main disadvantage is that this choice requires the system administrator to properly configure the bridge interface, IP forwarding and NAT, DHCP server (if required by the VM) and the packet filter to provide adequate network isolation.
+
+### Host
+
+Host networking can be enabled by specifying `--net-host` argument to `vetu run` and has the following advantages:
+
+* it is fast, because all the processing and routing is done in the kernel
+* no DHCP server is required: Vetu will assign the first available /30 subnet from the private IPv4 address space (excluding parts of that address space already used on the host machine)
+
+The main disadvantage is that this choice requires the system administrator to properly configure the IP forwarding and NAT and the packet filter to provide adequate network isolation.
 
 ## FAQ
 

--- a/internal/command/run/run.go
+++ b/internal/command/run/run.go
@@ -7,6 +7,7 @@ import (
 	"github.com/cirruslabs/vetu/internal/name/localname"
 	"github.com/cirruslabs/vetu/internal/network"
 	"github.com/cirruslabs/vetu/internal/network/bridged"
+	"github.com/cirruslabs/vetu/internal/network/host"
 	"github.com/cirruslabs/vetu/internal/network/software"
 	"github.com/cirruslabs/vetu/internal/storage/local"
 	"github.com/cirruslabs/vetu/internal/vmconfig"
@@ -19,6 +20,7 @@ import (
 )
 
 var netBridged string
+var netHost bool
 
 func NewCommand() *cobra.Command {
 	cmd := &cobra.Command{
@@ -30,6 +32,9 @@ func NewCommand() *cobra.Command {
 
 	cmd.Flags().StringVar(&netBridged, "net-bridged", "", "specify a bridge interface "+
 		"to attach the VM to instead of using the software TCP/IP stack by default")
+	cmd.Flags().BoolVar(&netHost, "net-host", false, "use host-networking "+
+		"(assigns the first available /30 subnet from the private IPv4 address space to the "+
+		"\"vetu*\" interface and serves it using the built-in DHCP server to the VM)")
 
 	return cmd
 }
@@ -74,6 +79,8 @@ func runRun(cmd *cobra.Command, args []string) error {
 	switch {
 	case netBridged != "":
 		network, err = bridged.New(netBridged)
+	case netHost:
+		network, err = host.New(vmConfig.MACAddress.HardwareAddr)
 	default:
 		network, err = software.New(vmConfig.MACAddress.HardwareAddr)
 	}

--- a/internal/network/host/dhcp.go
+++ b/internal/network/host/dhcp.go
@@ -1,0 +1,75 @@
+package host
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"github.com/insomniacslk/dhcp/dhcpv4"
+	"github.com/insomniacslk/dhcp/dhcpv4/server4"
+	"net"
+	"time"
+)
+
+var ErrInitFailed = errors.New("failed to initialize DHCP server")
+
+type DHCP struct {
+	gatewayIP net.IP
+	vmIP      net.IP
+
+	server *server4.Server
+}
+
+func NewDHCPServer(ifname string, gatewayIP net.IP, vmIP net.IP) (*DHCP, error) {
+	dhcp := &DHCP{
+		gatewayIP: gatewayIP,
+		vmIP:      vmIP,
+	}
+
+	server, err := server4.NewServer(ifname, nil, dhcp.handle)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrInitFailed, err)
+	}
+	dhcp.server = server
+
+	return dhcp, nil
+}
+
+func (dhcp *DHCP) Run(ctx context.Context) error {
+	go func() {
+		<-ctx.Done()
+		dhcp.server.Close()
+	}()
+
+	return dhcp.server.Serve()
+}
+
+func (dhcp *DHCP) handle(conn net.PacketConn, peer net.Addr, request *dhcpv4.DHCPv4) {
+	var messageType dhcpv4.MessageType
+
+	switch request.MessageType() {
+	case dhcpv4.MessageTypeDiscover:
+		messageType = dhcpv4.MessageTypeOffer
+	case dhcpv4.MessageTypeRequest:
+		messageType = dhcpv4.MessageTypeAck
+	default:
+		return
+	}
+
+	reply, err := dhcpv4.NewReplyFromRequest(request,
+		dhcpv4.WithMessageType(messageType),
+		dhcpv4.WithYourIP(dhcp.vmIP),
+		dhcpv4.WithOption(dhcpv4.OptSubnetMask(net.CIDRMask(29, 32))),
+		dhcpv4.WithRouter(dhcp.gatewayIP),
+		dhcpv4.WithDNS(net.ParseIP("8.8.8.8"), net.ParseIP("8.8.4.4")),
+		dhcpv4.WithOption(dhcpv4.OptIPAddressLeaseTime(10*time.Minute)),
+		dhcpv4.WithOption(dhcpv4.OptServerIdentifier(dhcp.gatewayIP)),
+	)
+	if err != nil {
+		return
+	}
+
+	_, err = conn.WriteTo(reply.ToBytes(), peer)
+	if err != nil {
+		return
+	}
+}

--- a/internal/network/host/host.go
+++ b/internal/network/host/host.go
@@ -1,0 +1,102 @@
+//go:build linux
+
+package host
+
+import (
+	"context"
+	"fmt"
+	"github.com/cirruslabs/vetu/internal/network/subnetfinder"
+	"github.com/cirruslabs/vetu/internal/tuntap"
+	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
+	"net"
+	"os"
+	"time"
+)
+
+type Network struct {
+	tapFile *os.File
+}
+
+func New(vmHardwareAddr net.HardwareAddr) (*Network, error) {
+	// Create a TAP interface
+	tapName, tapFile, err := tuntap.CreateTAP("vetu%d", unix.IFF_VNET_HDR)
+	if err != nil {
+		return nil, err
+	}
+
+	// Locate the TAP interface
+	tapLink, err := netlink.LinkByName(tapName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to find the TAP interface %q that we've just created: %v",
+			tapName, err)
+	}
+
+	// Bring the TAP interface up
+	if err := netlink.LinkSetUp(tapLink); err != nil {
+		return nil, fmt.Errorf("failed to bring the TAP interface %q up: %v", tapName, err)
+	}
+
+	// Find an available subnet to use
+	hostIP, vmIP, _, network, err := subnetfinder.FindAvailableSubnet(29)
+	if err != nil {
+		return nil, err
+	}
+
+	// Work around systemd-udevd(8) imposing its own random MAC-address on the interface[1]
+	// shortly after we create it, which results in the removal of our static neighbor.
+	//
+	// [1]: https://github.com/systemd/systemd/issues/21185
+	time.Sleep(100 * time.Millisecond)
+
+	// Add a permanent neighbor so that "vetu ip" would work
+	if err := netlink.NeighAdd(&netlink.Neigh{
+		LinkIndex:    tapLink.Attrs().Index,
+		IP:           vmIP,
+		HardwareAddr: vmHardwareAddr,
+		State:        netlink.NUD_PERMANENT,
+	}); err != nil {
+		return nil, fmt.Errorf("failed to add a permanent neighbor %s -> %s on an interface %s: %v",
+			vmIP, vmHardwareAddr, tapLink.Attrs().Name, err)
+	}
+
+	// Add an address to the TAP interface so that we would be able to
+	// connect to the VM by using an IP address returned by "vetu ip"
+	if err := netlink.AddrAdd(tapLink, &netlink.Addr{
+		IPNet: &net.IPNet{
+			IP:   hostIP,
+			Mask: network.Mask,
+		},
+	}); err != nil {
+		return nil, fmt.Errorf("failed to assign address %s to an interface %q: %v",
+			hostIP, tapLink.Attrs().Name, err)
+	}
+
+	// Provide a DHCP service
+	dhcp, err := NewDHCPServer(tapLink.Attrs().Name, hostIP, vmIP)
+	if err != nil {
+		return nil, fmt.Errorf("failed to instantiate a DHCP server: %v", err)
+	}
+
+	go func() {
+		if err := dhcp.Run(context.Background()); err != nil {
+			panic(err)
+		}
+	}()
+
+	return &Network{
+		tapFile,
+	}, nil
+}
+
+func (network *Network) SupportsOffload() bool {
+	return true
+}
+
+func (network *Network) Tap() *os.File {
+	return network.tapFile
+}
+
+func (network *Network) Close() error {
+	return nil
+}

--- a/internal/network/host/host_unsupported.go
+++ b/internal/network/host/host_unsupported.go
@@ -1,0 +1,29 @@
+//go:build !linux
+
+package host
+
+import (
+	"errors"
+	"net"
+	"os"
+)
+
+var ErrNotSupported = errors.New("host networking is not supported on this platform")
+
+type Network struct{}
+
+func New(_ net.HardwareAddr) (*Network, error) {
+	return nil, ErrNotSupported
+}
+
+func (network *Network) SupportsOffload() bool {
+	return false
+}
+
+func (network *Network) Tap() *os.File {
+	return nil
+}
+
+func (network *Network) Close() error {
+	return nil
+}

--- a/internal/network/software/software.go
+++ b/internal/network/software/software.go
@@ -9,6 +9,7 @@ import (
 	"github.com/cirruslabs/vetu/internal/afpacket"
 	"github.com/cirruslabs/vetu/internal/network/software/dhcp"
 	"github.com/cirruslabs/vetu/internal/network/software/gvisor"
+	"github.com/cirruslabs/vetu/internal/network/subnetfinder"
 	"github.com/cirruslabs/vetu/internal/tuntap"
 	"github.com/vishvananda/netlink"
 	"golang.org/x/sys/unix"
@@ -44,7 +45,7 @@ func New(vmHardwareAddr net.HardwareAddr) (*Network, error) {
 	}
 
 	// Find an available subnet to use
-	gatewayIP, vmIP, hostIP, network, err := FindAvailableSubnet(29)
+	gatewayIP, vmIP, hostIP, network, err := subnetfinder.FindAvailableSubnet(29)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/network/subnetfinder/subnetfinder.go
+++ b/internal/network/subnetfinder/subnetfinder.go
@@ -1,4 +1,4 @@
-package software
+package subnetfinder
 
 import (
 	"fmt"

--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -2,4 +2,4 @@
 
 set -e
 
-/sbin/setcap cap_net_raw,cap_net_admin+eip /usr/bin/vetu
+/sbin/setcap cap_net_raw,cap_net_admin,cap_net_bind_service+eip /usr/bin/vetu


### PR DESCRIPTION
Unfortunately, after researching options that the Linux provides for preventing ARP spoofing (basically you either disable ARP or filter it using a firewall), it would be pretty hard to securely use `--net-bridged` from the Vetu due to its daemon-less'ness.

To explain this better, LXD implements [bridged NIC security](https://documentation.ubuntu.com/lxd/en/stable-4.0/security/#bridged-nic-security) by adding and removing [`ebtables` or `nftables`](https://github.com/canonical/lxd/blob/000b1ab2a9e141a926e4db1ac4b343a743cc99f2/lxd/firewall/drivers/drivers_xtables.go#L1002) rules for each container/VM. This is great option for daemon, but not for a tool like Vetu, because we cannot guarantee that the firewall rules will be removed after the `vetu run` process finishes.

I've also looked into using network namespaces, XDP or Open vSwitch, but these options seem to be grossly complicated for what we're trying to achieve.

With the new networking type in this PR, we simply create a TAP interface and it is destroyed once `vetu run` process is destroyed. The ARP spoofing protection is achieved by using the `nftables` rules that drop anything but the ARP request from the guest. We add a static ARP neighbor to the TAP interface and run the DHCP server on it serving the next unused /30 network from the private IPv4 address space.

If we were to use the bridge, the ARP neighbors we add to it would not be removed once the `vetu run` process finishes, as they'll be associated with the bridge, which is persistent across multiple `vetu run` runs. We'd also need to implement some kind of DHCP snooping to figure out which IP was given for which VM by the DHCP server that the host will run.

P.S. I've also considered completely [disabling the ARP](https://superuser.com/a/399541) on each TAP interface, but that would require us to run an ARP server in `vetu run` in addition to the DHCP server, otherwise guest won't be able to communicate with the host. Thus, the `nftables` option was choosen to simplify things.