### PR TITLE
vetu set: support --disk-size argument

### DIFF
--- a/internal/command/list/list.go
+++ b/internal/command/list/list.go
@@ -94,7 +94,7 @@ func addVMsToTable(table *uitable.Table, source string, list listFunc) error {
 			return err
 		}
 
-		table.AddRow(source, name, humanize.IBytes(size), vmDir.State())
+		table.AddRow(source, name, humanize.Bytes(size), vmDir.State())
 	}
 
 	return nil

--- a/internal/command/set/set.go
+++ b/internal/command/set/set.go
@@ -31,7 +31,7 @@ func NewCommand() *cobra.Command {
 	cmd.Flags().Uint16Var(&memory, "memory", 4096, "amount of memory to use "+
 		"for the VM in MiB (mebibytes)")
 	cmd.Flags().Uint16Var(&diskSize, "disk-size", 0, "resize the primary VMs disk "+
-		"to the specified size in GB (note that the disk size can only be increased to avoid loosing data)")
+		"to the specified size in GB (note that the disk size can only be increased to avoid losing data)")
 
 	return cmd
 }

--- a/internal/command/set/set.go
+++ b/internal/command/set/set.go
@@ -1,13 +1,23 @@
 package set
 
 import (
+	"errors"
+	"fmt"
 	"github.com/cirruslabs/vetu/internal/name/localname"
 	"github.com/cirruslabs/vetu/internal/storage/local"
+	"github.com/cirruslabs/vetu/internal/vmconfig"
+	"github.com/cirruslabs/vetu/internal/vmdirectory"
+	"github.com/dustin/go-humanize"
 	"github.com/spf13/cobra"
+	"os"
+	"path/filepath"
 )
 
 var cpu uint8
 var memory uint16
+var diskSize uint16
+
+var ErrSet = errors.New("failed to set VM configuration")
 
 func NewCommand() *cobra.Command {
 	cmd := &cobra.Command{
@@ -20,6 +30,8 @@ func NewCommand() *cobra.Command {
 	cmd.Flags().Uint8Var(&cpu, "cpu", 2, "number of VM CPUs to use for the VM")
 	cmd.Flags().Uint16Var(&memory, "memory", 4096, "amount of memory to use "+
 		"for the VM in MiB (mebibytes)")
+	cmd.Flags().Uint16Var(&diskSize, "disk-size", 0, "resize the primary VMs disk "+
+		"to the specified size in GB (note that the disk size can only be increased to avoid loosing data)")
 
 	return cmd
 }
@@ -47,5 +59,45 @@ func runSet(cmd *cobra.Command, args []string) error {
 		vmConfig.MemorySize = uint64(memory) * 1024 * 1024
 	}
 
+	if diskSize != 0 {
+		if err := resizeDisk(vmDir, vmConfig); err != nil {
+			return err
+		}
+	}
+
 	return vmDir.SetConfig(&vmConfig)
+}
+
+func resizeDisk(vmDir *vmdirectory.VMDirectory, vmConfig vmconfig.VMConfig) error {
+	if len(vmConfig.Disks) < 1 {
+		return fmt.Errorf("%w: VM has no disks", ErrSet)
+	}
+
+	diskFile, err := os.OpenFile(filepath.Join(vmDir.Path(), vmConfig.Disks[0].Name), os.O_RDWR, 0600)
+	if err != nil {
+		return fmt.Errorf("%w: failed to open disk %s: %v", ErrSet, vmConfig.Disks[0].Name, err)
+	}
+
+	diskStat, err := diskFile.Stat()
+	if err != nil {
+		return fmt.Errorf("%w: failed to retrieve the size of disk %s: %v",
+			ErrSet, vmConfig.Disks[0].Name, err)
+	}
+
+	desiredDiskSizeBytes := int64(diskSize) * humanize.GByte
+
+	if actualDiskSizeBytes := diskStat.Size(); desiredDiskSizeBytes <= actualDiskSizeBytes {
+		return fmt.Errorf("%w: new disk size of %s should be larger than the current disk size of %s",
+			ErrSet, humanize.Bytes(uint64(desiredDiskSizeBytes)), humanize.Bytes(uint64(actualDiskSizeBytes)))
+	}
+
+	if err := diskFile.Truncate(desiredDiskSizeBytes); err != nil {
+		return fmt.Errorf("%w: failed to truncate disk %s: %v", ErrSet, vmConfig.Disks[0].Name, err)
+	}
+
+	if err := diskFile.Close(); err != nil {
+		return fmt.Errorf("%w: failed to close disk %s: %v", ErrSet, vmConfig.Disks[0].Name, err)
+	}
+
+	return nil
 }


### PR DESCRIPTION
This will allow resizing smaller Linux images generated as a result of https://github.com/cirruslabs/linux-image-templates/pull/7.