### PR TITLE
vetu clone: use a shared lock

### DIFF
--- a/internal/command/clone/clone.go
+++ b/internal/command/clone/clone.go
@@ -2,6 +2,7 @@ package clone
 
 import (
 	"fmt"
+	"github.com/cirruslabs/vetu/internal/filelock"
 	"github.com/cirruslabs/vetu/internal/globallock"
 	"github.com/cirruslabs/vetu/internal/name"
 	"github.com/cirruslabs/vetu/internal/name/localname"
@@ -69,7 +70,7 @@ func runClone(cmd *cobra.Command, args []string) error {
 			return nil, err
 		}
 
-		lock, err := srcVMDir.FileLock()
+		lock, err := srcVMDir.FileLock(filelock.LockShared)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/command/push/push.go
+++ b/internal/command/push/push.go
@@ -2,6 +2,7 @@ package push
 
 import (
 	"github.com/cirruslabs/vetu/internal/dockerhosts"
+	"github.com/cirruslabs/vetu/internal/filelock"
 	"github.com/cirruslabs/vetu/internal/globallock"
 	"github.com/cirruslabs/vetu/internal/name/localname"
 	"github.com/cirruslabs/vetu/internal/name/remotename"
@@ -50,7 +51,7 @@ func runPush(cmd *cobra.Command, args []string) error {
 			return nil, err
 		}
 
-		lock, err := vmDir.FileLock()
+		lock, err := vmDir.FileLock(filelock.LockShared)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/command/run/run.go
+++ b/internal/command/run/run.go
@@ -3,6 +3,7 @@ package run
 import (
 	"fmt"
 	"github.com/cirruslabs/vetu/internal/externalcommand/cloudhypervisor"
+	"github.com/cirruslabs/vetu/internal/filelock"
 	"github.com/cirruslabs/vetu/internal/globallock"
 	"github.com/cirruslabs/vetu/internal/name/localname"
 	"github.com/cirruslabs/vetu/internal/network"
@@ -57,7 +58,7 @@ func runRun(cmd *cobra.Command, args []string) error {
 			return nil, err
 		}
 
-		lock, err := vmDir.FileLock()
+		lock, err := vmDir.FileLock(filelock.LockExclusive)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/command/set/set.go
+++ b/internal/command/set/set.go
@@ -3,6 +3,7 @@ package set
 import (
 	"errors"
 	"fmt"
+	"github.com/cirruslabs/vetu/internal/filelock"
 	"github.com/cirruslabs/vetu/internal/globallock"
 	"github.com/cirruslabs/vetu/internal/name/localname"
 	"github.com/cirruslabs/vetu/internal/storage/local"
@@ -52,7 +53,7 @@ func runSet(cmd *cobra.Command, args []string) error {
 			return nil, err
 		}
 
-		lock, err := vmDir.FileLock()
+		lock, err := vmDir.FileLock(filelock.LockExclusive)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/globallock/globallock.go
+++ b/internal/globallock/globallock.go
@@ -21,7 +21,7 @@ func With[T any](ctx context.Context, cb func() (T, error)) (T, error) {
 		return result, err
 	}
 
-	lock, err := filelock.New(homeDir)
+	lock, err := filelock.New(homeDir, filelock.LockExclusive)
 	if err != nil {
 		return result, err
 	}

--- a/internal/storage/local/local.go
+++ b/internal/storage/local/local.go
@@ -2,6 +2,7 @@ package local
 
 import (
 	"fmt"
+	"github.com/cirruslabs/vetu/internal/filelock"
 	"github.com/cirruslabs/vetu/internal/homedir"
 	"github.com/cirruslabs/vetu/internal/name/localname"
 	"github.com/cirruslabs/vetu/internal/vmdirectory"
@@ -84,7 +85,7 @@ func Delete(name localname.LocalName) error {
 		return fmt.Errorf("cannot remove VM %s: %v", name.String(), err)
 	}
 
-	lock, err := vmDir.FileLock()
+	lock, err := vmDir.FileLock(filelock.LockExclusive)
 	if err != nil {
 		return fmt.Errorf("cannot remove VM %s: %v", name.String(), err)
 	}

--- a/internal/storage/remote/remote.go
+++ b/internal/storage/remote/remote.go
@@ -177,7 +177,7 @@ func RegistryLock(name remotename.RemoteName) (*filelock.FileLock, error) {
 		return nil, err
 	}
 
-	return filelock.New(registryDir)
+	return filelock.New(registryDir, filelock.LockExclusive)
 }
 
 func PathForResolved(name remotename.RemoteName) (string, error) {

--- a/internal/storage/temporary/temporary.go
+++ b/internal/storage/temporary/temporary.go
@@ -26,7 +26,7 @@ func CreateFrom(srcDir string) (*vmdirectory.VMDirectory, error) {
 		return nil, err
 	}
 
-	lock, err := filelock.New(intermediateDir)
+	lock, err := filelock.New(intermediateDir, filelock.LockExclusive)
 	if err != nil {
 		return nil, err
 	}
@@ -112,7 +112,7 @@ func CreateTryLocked() (*vmdirectory.VMDirectory, *filelock.FileLock, error) {
 		return nil, nil, err
 	}
 
-	lock, err := vmDir.FileLock()
+	lock, err := vmDir.FileLock(filelock.LockExclusive)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -138,7 +138,7 @@ func GC() error {
 	for _, dirEntry := range dirEntries {
 		path := filepath.Join(baseDir, dirEntry.Name())
 
-		lock, err := filelock.New(path)
+		lock, err := filelock.New(path, filelock.LockExclusive)
 		if err != nil {
 			// It's quite possible that while iterating and removing the temporary directories,
 			// some of the directories were already moved to their final destination, so ignore them

--- a/internal/vmdirectory/vmdirectory.go
+++ b/internal/vmdirectory/vmdirectory.go
@@ -30,8 +30,8 @@ func Load(path string) (*VMDirectory, error) {
 	return vmDir, nil
 }
 
-func (vmDir *VMDirectory) FileLock() (*filelock.FileLock, error) {
-	return filelock.New(vmDir.Path())
+func (vmDir *VMDirectory) FileLock(lockType filelock.LockType) (*filelock.FileLock, error) {
+	return filelock.New(vmDir.Path(), lockType)
 }
 
 func (vmDir *VMDirectory) PIDLock() (*pidlock.PIDLock, error) {


### PR DESCRIPTION
Otherwise two `vetu clone` instances won't be able to clone a single OCI VM image concurrently.