### PR TITLE
vetu clone: opportunistically zero-copy of files on Linux

### DIFF
--- a/internal/zerocopy/zerocopy_linux.go
+++ b/internal/zerocopy/zerocopy_linux.go
@@ -1,0 +1,9 @@
+package zerocopy
+
+import (
+	"golang.org/x/sys/unix"
+)
+
+func Clone(destFd int, srcFd int) error {
+	return unix.IoctlFileClone(destFd, srcFd)
+}

--- a/internal/zerocopy/zerocopy_unsupported.go
+++ b/internal/zerocopy/zerocopy_unsupported.go
@@ -1,0 +1,9 @@
+//go:build !linux
+
+package zerocopy
+
+import "golang.org/x/sys/unix"
+
+func Clone(destFd int, srcFd int) error {
+	return unix.ENOTSUP
+}


### PR DESCRIPTION
Tested on Linux 6.7 with a `bcachefs`.