### PR TITLE
vetu list: stable sort order: first local, then oci

### DIFF
--- a/internal/name/remotename/remotename_test.go
+++ b/internal/name/remotename/remotename_test.go
@@ -1,4 +1,3 @@
-//nolint:goconst // it's OK to have multiple occurrences of the same string in tests
 package remotename_test
 
 import (


### PR DESCRIPTION
Noticed this when running `vetu list` multiple times.