### PR TITLE
Sentry: enrich events with the program arguments and env. variables

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -54,15 +54,6 @@ linters:
     - whitespace
 
   disable:
-    # Messages like "struct of size 104 bytes could be of size 96 bytes" from a package
-    # that was last updated 2 years ago[1] are barely helpful.
-    #
-    # After all, we're writing the code for other people, so let's trust the compiler here (that's
-    # constantly evolving compared to this linter) and revisit this if memory usage becomes a problem.
-    #
-    # [1]: https://github.com/mdempsky/maligned/commit/6e39bd26a8c8b58c5a22129593044655a9e25959
-    - maligned
-
     # We don't have high-performance requirements at this moment, so sacrificing
     # the code readability for marginal performance gains is not worth it.
     - prealloc
@@ -75,18 +66,11 @@ linters:
     # Unfortunately, we use globals due to how spf13/cobra works.
     - gochecknoglobals
 
-    # That's fine that some Proto objects don't have all fields initialized
-    - exhaustivestruct
-
     # Style linters that are total nuts.
     - wsl
     - gofumpt
     - goimports
     - funlen
-
-    # This conflicts with the Protocol Buffers Version 3 design,
-    # which is largely based on default values for struct fields.
-    - exhaustivestruct
 
     # Enough parallelism for now.
     - paralleltest

--- a/cmd/vetu/main.go
+++ b/cmd/vetu/main.go
@@ -45,6 +45,14 @@ func main() {
 		})
 	}
 
+	// Enrich future events with the program arguments and environment variables
+	sentry.ConfigureScope(func(scope *sentry.Scope) {
+		scope.SetContext("os", map[string]interface{}{
+			"args":    os.Args,
+			"environ": os.Environ(),
+		})
+	})
+
 	// Set up a signal-interruptible context
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
 


### PR DESCRIPTION
This way it'll be easy to determine which Vetu command was invoked.