### PR TITLE
vetu run: do not panic on context cancellation

### DIFF
--- a/internal/network/software/dhcp/dhcp.go
+++ b/internal/network/software/dhcp/dhcp.go
@@ -62,7 +62,7 @@ func New(st *stack.Stack, gatewayIP net.IP, vmIP net.IP) (*DHCP, error) {
 func (dhcp *DHCP) Run(ctx context.Context) error {
 	go func() {
 		<-ctx.Done()
-		dhcp.server.Close()
+		_ = dhcp.server.Close()
 	}()
 
 	return dhcp.server.Serve()

--- a/internal/network/software/software.go
+++ b/internal/network/software/software.go
@@ -99,12 +99,20 @@ func New(vmHardwareAddr net.HardwareAddr) (*Network, error) {
 
 	go func() {
 		if err := gvisor.Run(ctx); err != nil {
+			if errors.Is(ctx.Err(), context.Canceled) {
+				return
+			}
+
 			panic(err)
 		}
 	}()
 
 	go func() {
-		if err := dhcp.Run(context.Background()); err != nil {
+		if err := dhcp.Run(ctx); err != nil {
+			if errors.Is(ctx.Err(), context.Canceled) {
+				return
+			}
+
 			panic(err)
 		}
 	}()


### PR DESCRIPTION
When context is canceled `dhcp.server.Serve()` might return `io.EOF`, which causes the "vetu run" to panic. Ignore any errors that occured after the context cancellation.