### PR TITLE
binaryfetcher: atomically rename binary file when fetch succeeds

### DIFF
--- a/internal/filelock/filelock_test.go
+++ b/internal/filelock/filelock_test.go
@@ -24,7 +24,7 @@ func TestMain(m *testing.M) {
 	} else if lockPath, ok := os.LookupEnv(envTestHelperTrylockShared); ok {
 		testHelperTrylockShared(lockPath)
 	} else {
-		m.Run()
+		os.Exit(m.Run())
 	}
 }
 

--- a/internal/pidlock/pidlock_test.go
+++ b/internal/pidlock/pidlock_test.go
@@ -25,7 +25,7 @@ func TestMain(m *testing.M) {
 	} else if lockPath, ok := os.LookupEnv(envTestHelperPid); ok {
 		testHelperPid(lockPath)
 	} else {
-		m.Run()
+		os.Exit(m.Run())
 	}
 }
 

--- a/internal/sparseio/sparseio_test.go
+++ b/internal/sparseio/sparseio_test.go
@@ -40,7 +40,6 @@ func TestCopyRandomized(t *testing.T) {
 
 		// Randomize the contents of some chunks
 		if rand.Intn(2) == 1 {
-			//nolint:staticcheck // what's the alternative to the deprecated rand.Read() anyways?
 			_, err = rand.Read(chunk)
 			require.NoError(t, err)
 		}


### PR DESCRIPTION
Otherwise an empty file will be created on errors like HTTP 403 and cached, which will prevent future VMs from running.