### PR TITLE
Software netowrking: increase systemd-udevd(8) workaround timeout to 1s

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,6 +8,10 @@ linters-settings:
   exhaustive:
     default-signifies-exhaustive: true
 
+  gosec:
+    excludes:
+      - G115
+
 linters:
   enable:
     - asciicheck

--- a/internal/network/software/software.go
+++ b/internal/network/software/software.go
@@ -54,7 +54,7 @@ func New(vmHardwareAddr net.HardwareAddr) (*Network, error) {
 	// shortly after we create it, which results in the removal of our static neighbor.
 	//
 	// [1]: https://github.com/systemd/systemd/issues/21185
-	time.Sleep(100 * time.Millisecond)
+	time.Sleep(1 * time.Second)
 
 	// Add a permanent neighbor so that "vetu ip" would work
 	if err := netlink.NeighAdd(&netlink.Neigh{

--- a/internal/sparseio/sparseio_test.go
+++ b/internal/sparseio/sparseio_test.go
@@ -1,6 +1,7 @@
 package sparseio_test
 
 import (
+	cryptorand "crypto/rand"
 	"github.com/cirruslabs/vetu/internal/sparseio"
 	"github.com/dustin/go-humanize"
 	"github.com/opencontainers/go-digest"
@@ -40,7 +41,7 @@ func TestCopyRandomized(t *testing.T) {
 
 		// Randomize the contents of some chunks
 		if rand.Intn(2) == 1 {
-			_, err = rand.Read(chunk)
+			_, err = cryptorand.Read(chunk)
 			require.NoError(t, err)
 		}
 


### PR DESCRIPTION
It seems that on slow EBS volumes 100ms might not be enough.