### PR TITLE
vetu {create,clone}: do not perform target local VM existence check

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,8 +19,6 @@ linters:
     - dupl
     - errcheck
     - exhaustive
-    - exportloopref
-    - exportloopref
     - gochecknoinits
     - gocognit
     - goconst
@@ -96,9 +94,6 @@ linters:
     # No way to disable the "exported" check for the whole project[1]
     # [1]: https://github.com/mgechev/revive/issues/244#issuecomment-560512162
     - revive
-
-    # Unfortunately too much false-positives, e.g. for a 0700 umask or number 10 when using strconv.FormatInt()
-    - gomnd
 
     # Needs package whitelists
     - depguard

--- a/internal/command/clone/clone.go
+++ b/internal/command/clone/clone.go
@@ -1,7 +1,6 @@
 package clone
 
 import (
-	"fmt"
 	"github.com/cirruslabs/vetu/internal/filelock"
 	"github.com/cirruslabs/vetu/internal/globallock"
 	"github.com/cirruslabs/vetu/internal/name"
@@ -104,11 +103,6 @@ func runClone(cmd *cobra.Command, args []string) error {
 	}
 
 	_, err = globallock.With[struct{}](cmd.Context(), func() (struct{}, error) {
-		// Ensure the target VM directory does not exist
-		if local.Exists(dstLocalName) {
-			return struct{}{}, fmt.Errorf("VM %q already exists", dstLocalName)
-		}
-
 		if err := local.MoveIn(dstLocalName, tmpVMDir); err != nil {
 			return struct{}{}, err
 		}

--- a/internal/command/create/create.go
+++ b/internal/command/create/create.go
@@ -113,10 +113,6 @@ func runCreate(cmd *cobra.Command, args []string) error {
 			return struct{}{}, err
 		}
 
-		if local.Exists(localName) {
-			return struct{}{}, fmt.Errorf("VM %q already exists", localName.String())
-		}
-
 		return struct{}{}, local.MoveIn(localName, vmDir)
 	})
 


### PR DESCRIPTION
To be consistent with Tart.