### PR TITLE
tart {create,clone}: fix "file exists" eror due to moving directories

### DIFF
--- a/internal/rename/rename_darwin.go
+++ b/internal/rename/rename_darwin.go
@@ -1,0 +1,14 @@
+package rename
+
+import (
+	"golang.org/x/sys/unix"
+)
+
+func Rename(oldpath string, newpath string) error {
+	err := unix.RenameatxNp(unix.AT_FDCWD, oldpath, unix.AT_FDCWD, newpath, unix.RENAME_SWAP)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/internal/rename/rename_linux.go
+++ b/internal/rename/rename_linux.go
@@ -1,0 +1,14 @@
+package rename
+
+import (
+	"golang.org/x/sys/unix"
+)
+
+func Rename(oldpath string, newpath string) error {
+	err := unix.Renameat2(unix.AT_FDCWD, oldpath, unix.AT_FDCWD, newpath, unix.RENAME_EXCHANGE)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/internal/rename/rename_unsupported.go
+++ b/internal/rename/rename_unsupported.go
@@ -1,0 +1,9 @@
+//go:build !linux && !darwin
+
+package rename
+
+import "fmt"
+
+func Rename(oldDir string, newDir string) error {
+	return fmt.Errorf("atomic rename of directories is not supported on this platform")
+}


### PR DESCRIPTION
This is a continuation of https://github.com/cirruslabs/vetu/pull/62, in which I've removed the unnecessary check, but haven't considered the fact that we're moving directories, not files.

As a result"file exists" error is thrown when trying to clone and overwrite a VM.

With this change, we use `rename.Rename()` instead of `os.Rename()` when the latter fails, and then delete the overwritten file/directory at the end.

The idea is to have a behavior similar to [Swift's `replaceItemAt()`](https://developer.apple.com/documentation/foundation/filemanager/2293212-replaceitemat)'s.