### PR TITLE
Fix resizeDisk equality error

### DIFF
--- a/internal/command/set/set.go
+++ b/internal/command/set/set.go
@@ -108,7 +108,7 @@ func resizeDisk(vmDir *vmdirectory.VMDirectory, vmConfig *vmconfig.VMConfig) err
 
 	desiredDiskSizeBytes := int64(diskSize) * humanize.GByte
 
-	if actualDiskSizeBytes := diskStat.Size(); desiredDiskSizeBytes <= actualDiskSizeBytes {
+	if actualDiskSizeBytes := diskStat.Size(); desiredDiskSizeBytes < actualDiskSizeBytes {
 		return fmt.Errorf("%w: new disk size of %s should be larger than the current disk size of %s",
 			ErrSet, humanize.Bytes(uint64(desiredDiskSizeBytes)), humanize.Bytes(uint64(actualDiskSizeBytes)))
 	}


### PR DESCRIPTION
## Summary
- simplify `resizeDisk` size check by comparing to the actual size with `<`

Otherwise we can get:

```
*fmt.wrapError
vetu isolation failed: failed to configure VM "cirrus-cli-xxx": vetu command returned non-zero exit code: "failed to set VM configuration: new disk size of 20 GB should be larger than the current disk size of 20 GB"
```

------
https://chatgpt.com/codex/tasks/task_e_687116a5de208329b0524543964a6c5e